### PR TITLE
Proper handling of output to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ To dump the whole flash of my AR4518PW into some file, I do:
 ./brntool.py --read=AR4518PW_whole.dump --addr=0xB0000000 --verbose
 --size=0x400000
 
+If you specify `-` as the output filename in the `--read` option, the output will be sent to `stdout`.
+On a Windows platform you **must** call the script with the `–u` option in order to prevent the replacement
+of `'\x0a' ` by ` '\x0d\x0a' ` in this case.
+
 And then turn it on.
 
-A successful flash block read will output '.' while a botched one (a byte or
+A successful flash block read will output the address and size of the block while a botched one (a byte or
 more gets lost in the serial port) will output '!' and retry. Even so, unless
 in a hurry, I'd recommend to at least dump twice and compare the dumps, just
 to be on the safe side.

--- a/brntool.py
+++ b/brntool.py
@@ -60,7 +60,8 @@ def memread(ser,path,addr,size,verbose):
 	bs=10000 #10000 is usually the maximum size for an hexdump on brnboot.
 	get2menu(ser,verbose)
 	if path == "-":
-		fd=sys.stdout
+		# get sys.stdout in Python 2 or sys.stdout.buffer in Python 3
+		fd=getattr(sys.stdout, 'buffer', sys.stdout)
 	else:
 		fd=open(path,"wb")
 	while 0<size:


### PR DESCRIPTION
in Python 3 and on Windows. Stdout in text output (as opposed to binary).
It expects a string (not bytes) in Python 3. In Python 2 on Windows, any '\x0a' byte
will be converted  by '\x0d\x0a' when using stdout text output. This can be suppressed
by using the -u command line option.
